### PR TITLE
Moved CollisionManager.Update to after other object updates

### DIFF
--- a/EndGate/EndGate.Core.JS/Game.ts
+++ b/EndGate/EndGate.Core.JS/Game.ts
@@ -75,8 +75,8 @@ module EndGate {
         public _PrepareUpdate(): void {
             this._gameTime.Update();
 
-            this.CollisionManager.Update(this._gameTime);
             this.Update(this._gameTime);
+            this.CollisionManager.Update(this._gameTime);
         }
 
         /**


### PR DESCRIPTION
- Updated _PrepareUpdate() to move collision manager update
  after standard update method for all other objects
  this allows us to respond to collisions after all objects
  have moved but before the next draw.
